### PR TITLE
fix: rss loop http errors

### DIFF
--- a/src/commands/Rss/rss.js
+++ b/src/commands/Rss/rss.js
@@ -230,6 +230,7 @@ export default {
                     title: feedTitle,
                     url: feed,
                     oldData: parseFeed(feedData),
+                    errorCount: 0,
                     format: {
                         text: "**{title}**\n{description}\n\n<{link}>",
                         embed: {


### PR DESCRIPTION
**Description**

Ignores random "Bad Gateway" and such until they have been continously happening for the past hour.

**Changes**

Adds errorCount property to feed items in the database to track the errors. Checks error message in the catch block of fetchFeed in rssHandler.
